### PR TITLE
Change commented-out config to explicit False.

### DIFF
--- a/config/assembleCoadd.py
+++ b/config/assembleCoadd.py
@@ -14,5 +14,5 @@ config.badMaskPlanes += ["SUSPECT"]
 from lsst.pipe.tasks.selectImages import PsfWcsSelectImagesTask
 config.select.retarget(PsfWcsSelectImagesTask)
 
-# Place holder for later
-#config.doAttachTransmissionCurve = True
+# FUTURE: Set to True when we get transmission curves
+config.doAttachTransmissionCurve = False

--- a/config/makeCoaddTempExp.py
+++ b/config/makeCoaddTempExp.py
@@ -8,8 +8,8 @@ config.makePsfMatched = True
 config.warpAndPsfMatch.psfMatch.kernel['AL'].alardSigGauss = [1.0, 2.0, 4.5]
 config.modelPsf.defaultFwhm = 7.7
 
-# To be uncommented when we will run jointcal
-#config.doApplyUberCal = True
+# FUTURE: Set to True when we decide to run jointcal
+config.doApplyUberCal = False
 
-# To be uncommented when we will have sky background estimates
-#config.doApplySkyCorr = True
+# FUTURE: Set to True when we have sky background estimate
+config.doApplySkyCorr = False


### PR DESCRIPTION
Explicitly set config values instead of relying on defaults.
Add notes that we intend to turn these on in the future.