### PR TITLE
add Robert's suggested workaround for the median-bug in the ISR overscan correction

### DIFF
--- a/config/lsstCam.py
+++ b/config/lsstCam.py
@@ -5,5 +5,9 @@ if hasattr(config, 'ccdKeys'):
 
 config.isr.doLinearize = False
 config.isr.doDefect = False
-config.isr.doCrosstalk=True
+config.isr.doCrosstalk = True
 config.isr.doAddDistortionModel = False
+
+# Work-around for median-bug in overscan correction (DM-15203).
+config.isr.overscanFitType = 'POLY'
+config.isr.overscanOrder = 0


### PR DESCRIPTION
The need for these changes was noted by Robert in the [desc-dm-dc2 channel](https://lsstc.slack.com/archives/C978LTJGN/p1535461457000100)