### PR TITLE
Requesting a merge of DC2 Run1.2x configs

### DIFF
--- a/config/coaddDriver_noPSF.py
+++ b/config/coaddDriver_noPSF.py
@@ -1,0 +1,2 @@
+from lsst.pipe.tasks.selectImages import WcsSelectImagesTask
+config.select.retarget(WcsSelectImagesTask)

--- a/config/forcedPhotCcd.py
+++ b/config/forcedPhotCcd.py
@@ -6,4 +6,4 @@ config.measurement.load(os.path.join(getPackageDir("obs_lsst"), "config", "apert
 config.measurement.load(os.path.join(getPackageDir("obs_lsst"), "config", "kron.py"))
 config.load(os.path.join(getPackageDir("obs_lsst"), "config", "cmodel.py"))
 
-config.measurement.slots.instFlux = None
+config.measurement.slots.gaussianFlux = None

--- a/config/forcedPhotCoadd.py
+++ b/config/forcedPhotCoadd.py
@@ -8,7 +8,7 @@ config.measurement.load(os.path.join(getPackageDir("obs_lsst"), "config", "kron.
 config.measurement.load(os.path.join(getPackageDir("obs_lsst"), "config", "convolvedFluxes.py"))
 config.load(os.path.join(getPackageDir("obs_lsst"), "config", "cmodel.py"))
 
-config.measurement.slots.instFlux = None
+config.measurement.slots.gaussianFlux = None
 
 config.measurement.plugins['base_PixelFlags'].masksFpCenter.append('BRIGHT_OBJECT')
 config.measurement.plugins['base_PixelFlags'].masksFpAnywhere.append('BRIGHT_OBJECT')

--- a/config/isr.py
+++ b/config/isr.py
@@ -6,5 +6,10 @@ if hasattr(config, 'ccdKeys'):
 
 config.doLinearize = False
 config.doDefect = False
-config.doCrosstalk=True
+# skip xtalk for Run1.2x
+config.doCrosstalk = False
 config.doAddDistortionModel = False
+
+# Work-around for median-bug in overscan correction (DM-15203).
+config.overscanFitType = 'POLY'
+config.overscanOrder = 0

--- a/config/lsstCam.py
+++ b/config/lsstCam.py
@@ -5,5 +5,9 @@ if hasattr(config, 'ccdKeys'):
 
 config.isr.doLinearize = False
 config.isr.doDefect = False
-config.isr.doCrosstalk=True
+config.isr.doCrosstalk = True
 config.isr.doAddDistortionModel = False
+
+# Work-around for median-bug in overscan correction (DM-15203).
+config.isr.overscanFitType = 'POLY'
+config.isr.overscanOrder = 0

--- a/config/lsstCam.py
+++ b/config/lsstCam.py
@@ -5,7 +5,8 @@ if hasattr(config, 'ccdKeys'):
 
 config.isr.doLinearize = False
 config.isr.doDefect = False
-config.isr.doCrosstalk = True
+# For Run1.2x data, no crosstalk
+config.isr.doCrosstalk = False
 config.isr.doAddDistortionModel = False
 
 # Work-around for median-bug in overscan correction (DM-15203).

--- a/config/multiBandDriver.py
+++ b/config/multiBandDriver.py
@@ -8,3 +8,5 @@ for sub in ("mergeCoaddDetections", "measureCoaddSources", "mergeCoaddMeasuremen
     path = os.path.join(getPackageDir("obs_lsst"), "config", sub + ".py")
     if os.path.exists(path):
         getattr(config, sub).load(path)
+
+config.measureCoaddSources.propagateFlags.ccdName="detector"

--- a/config/processCcd.py
+++ b/config/processCcd.py
@@ -103,3 +103,8 @@ if "ext_convolved_ConvolvedFlux" in config.charImage.measurement.plugins:
 
 config.charImage.measurement.plugins["base_Jacobian"].pixelScale = 0.2
 config.calibrate.measurement.plugins["base_Jacobian"].pixelScale = 0.2
+
+# Prevent spurious detections in vignetting areas
+config.calibrate.detection.thresholdType='pixel_stdev'
+config.charImage.detection.thresholdType='pixel_stdev'
+


### PR DESCRIPTION
@johannct @boutigny @rearmstr @hsinfang We are trying to merge some remaining configuration parameters that we have been using for Run1.2x processing, before this package is officially part of the DMstack.  One change @jchiang87  I'm not sure we should merge to master is the workaround for the median-bug, as this might now be fixed in the later versions of the stack? https://github.com/lsst/obs_lsstCam/commit/5a17448f1c7db41246aee8a55af61ce4edd108dd
Is there anything missing that we should be sure to include that may be in use currently in the Run1.2p processing, Johann?